### PR TITLE
Added package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "author": "kopipejst <devet.sest@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/filiosoft/jqSnow.git"
+    "url": "https://github.com/kopipejst/jqSnow.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "jqsnow",
+  "title": "jQuery Snow Falling plugin",
+  "description": "jQuery Snow Falling plugin!",
+  "version": "1.0.0",
+  "homepage": "http://workshop.rs/2012/01/jquery-snow-falling-plugin/",
+  "author": "kopipejst <devet.sest@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/filiosoft/jqSnow.git"
+  }
+}


### PR DESCRIPTION
I'm using this with a project that uses NPM as a package manager. So I added a `package.json` file to make it work with NPM. 

Now you will be able to install jqSnow like this:
```
npm install https://github.com/kopipejst/jqSnow.git
```